### PR TITLE
Release 0.0.5

### DIFF
--- a/deco-slack/deco_slack/__init__.py
+++ b/deco-slack/deco_slack/__init__.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, List, Optional
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
-__version__ = "0.0.2"
+__version__ = "0.0.5"
 
 __all__ = [
     "__version__",

--- a/deco-slack/pyproject.toml
+++ b/deco-slack/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "deco_slack"
-version = "0.0.4"
+version = "0.0.5"
 description = "deco_slack notifies you if a method has completed successfully or not."
 authors = ["taross-f <taro.furuya@gmail.com>"]
 readme = "README.md"

--- a/deco-slack/tests/test_deco_slack.py
+++ b/deco-slack/tests/test_deco_slack.py
@@ -12,7 +12,7 @@ from deco_slack import (
 
 
 def test_version():
-    assert __version__ == "0.0.2"
+    assert __version__ == "0.0.5"
 
 
 class MockHandler(NotificationHandler):


### PR DESCRIPTION
## Summary

Version bump for the **0.0.5** release, which ships the recently merged security fixes and Python 3.14 support (#80).

### Changes
- Bump `version` to `0.0.5` in `pyproject.toml` (current PyPI latest is `0.0.4`).
- Fix `__version__` in `deco_slack/__init__.py`, which was out of sync (stuck at `0.0.2`), to `0.0.5`.
- Update the version assertion test accordingly.

### Release flow
Once this merges to `main`, pushing the `v0.0.5` tag triggers `publish.yml`, which builds and publishes to PyPI.

### Verification
- `poetry run pytest` → 11 passed
- `poetry build` → builds `deco_slack-0.0.5` sdist + wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkrFZ7vAUduJ4zfDJGEu7Q)_